### PR TITLE
Don't call setpgid() if we are already the process group leader.

### DIFF
--- a/bwctld/bwctld.c
+++ b/bwctld/bwctld.c
@@ -2566,7 +2566,7 @@ main(int argc, char *argv[])
          * kill call.) setsid handles this when daemonizing.
          */
         mypid = getpid();
-        if(setpgid(0,mypid) != 0){
+        if(getsid(0) != mypid && setpgid(0,mypid) != 0){
             I2ErrLog(errhand,"setpgid(): %M");
             exit(1);
         }


### PR DESCRIPTION
This allows bwctld -Z to run under OSX launchd with a plist file.
Fixes #10
